### PR TITLE
Add configurable QoS for the managed Syncthing process

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ The preferences window is used to point to a local running instance, a remote in
 It is possible to run your own instance and point to it for advanced/development purposes.
 You should only change the settings if you know what you are doing.
 
+The Syncthing process quality of service can be set to Normal, Utility, or Background in the
+preferences window. Background is the default for compatibility and reduces the process impact on
+foreground applications, but it can make large folder scans take longer. Changing this setting
+restarts the managed Syncthing process.
+
 Setting extra Syncthing command line parameters is a hidden feature. You need to write these using
 the application defaults configuration. The only current limitation the parameters cannot contain spaces!.
 In the example below the audit log is enabled:

--- a/syncthing/Base.lproj/STPreferencesWindowGeneralView.xib
+++ b/syncthing/Base.lproj/STPreferencesWindowGeneralView.xib
@@ -8,6 +8,9 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="STPreferencesGeneralViewController">
             <connections>
+                <outlet property="DaemonQoSBackground" destination="QoS-Bg-A01" id="QoS-Bg-O01"/>
+                <outlet property="DaemonQoSDefault" destination="QoS-Df-A01" id="QoS-Df-O01"/>
+                <outlet property="DaemonQoSUtility" destination="QoS-Ut-A01" id="QoS-Ut-O01"/>
                 <outlet property="ProxyURL" destination="X8z-m3-H7F" id="Fn0-3o-LfW"/>
                 <outlet property="StartAtLogin" destination="tYl-sb-Hga" id="nUj-DN-esv"/>
                 <outlet property="Syncthing_ApiKey" destination="B0w-Uv-22O" id="DX5-97-308"/>
@@ -20,7 +23,7 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="457" height="248"/>
+            <rect key="frame" x="0.0" y="0.0" width="457" height="303"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SPp-6x-JiZ">
                     <rect key="frame" x="18" y="121" width="49" height="16"/>
@@ -120,6 +123,52 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QoS-Lb-A01">
+                    <rect key="frame" x="18" y="56" width="49" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Priority" id="QoS-Lb-C01">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="QoS-Df-A01">
+                    <rect key="frame" x="71" y="56" width="75" height="18"/>
+                    <buttonCell key="cell" type="radio" title="Normal" bezelStyle="regularSquare" imagePosition="left" inset="2" id="QoS-Df-C01">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="clickedDaemonQualityOfService:" target="-2" id="QoS-Df-X01"/>
+                    </connections>
+                </button>
+                <button tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="QoS-Ut-A01">
+                    <rect key="frame" x="158" y="56" width="75" height="18"/>
+                    <buttonCell key="cell" type="radio" title="Utility" bezelStyle="regularSquare" imagePosition="left" inset="2" id="QoS-Ut-C01">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="clickedDaemonQualityOfService:" target="-2" id="QoS-Ut-X01"/>
+                    </connections>
+                </button>
+                <button tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="QoS-Bg-A01">
+                    <rect key="frame" x="245" y="56" width="110" height="18"/>
+                    <buttonCell key="cell" type="radio" title="Background" bezelStyle="regularSquare" imagePosition="left" inset="2" id="QoS-Bg-C01">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="clickedDaemonQualityOfService:" target="-2" id="QoS-Bg-X01"/>
+                    </connections>
+                </button>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QoS-Hp-A01">
+                    <rect key="frame" x="73" y="17" width="364" height="34"/>
+                    <textFieldCell key="cell" lineBreakMode="byWordWrapping" sendsActionOnEndEditing="YES" title="Background saves energy but can make large scans slower. Changes restart Syncthing automatically." id="QoS-Hp-C01">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="aC0-rw-4G1">
                     <rect key="frame" x="71" y="117" width="134" height="18"/>
                     <buttonCell key="cell" type="check" title="Show in menu bar" bezelStyle="regularSquare" imagePosition="left" inset="2" id="nB8-OA-X1F">
@@ -185,11 +234,22 @@
                 <constraint firstAttribute="trailing" secondItem="B0w-Uv-22O" secondAttribute="trailing" constant="20" symbolic="YES" id="lWZ-ef-Ed2"/>
                 <constraint firstItem="B0w-Uv-22O" firstAttribute="top" secondItem="kCf-gA-qTB" secondAttribute="bottom" constant="10" symbolic="YES" id="mg0-kD-bnu"/>
                 <constraint firstItem="N0T-mL-rWn" firstAttribute="leading" secondItem="kCf-gA-qTB" secondAttribute="leading" id="nfs-eY-QdR"/>
+                <constraint firstItem="QoS-Lb-A01" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="20" symbolic="YES" id="QoS-Lb-K01"/>
+                <constraint firstItem="QoS-Lb-A01" firstAttribute="firstBaseline" secondItem="QoS-Df-A01" secondAttribute="firstBaseline" id="QoS-Lb-K02"/>
+                <constraint firstItem="QoS-Df-A01" firstAttribute="leading" secondItem="kCf-gA-qTB" secondAttribute="leading" id="QoS-Df-K01"/>
+                <constraint firstItem="QoS-Df-A01" firstAttribute="top" secondItem="N0T-mL-rWn" secondAttribute="bottom" constant="14" id="QoS-Df-K02"/>
+                <constraint firstItem="QoS-Ut-A01" firstAttribute="leading" secondItem="QoS-Df-A01" secondAttribute="trailing" constant="12" id="QoS-Ut-K01"/>
+                <constraint firstItem="QoS-Ut-A01" firstAttribute="firstBaseline" secondItem="QoS-Df-A01" secondAttribute="firstBaseline" id="QoS-Ut-K02"/>
+                <constraint firstItem="QoS-Bg-A01" firstAttribute="leading" secondItem="QoS-Ut-A01" secondAttribute="trailing" constant="12" id="QoS-Bg-K01"/>
+                <constraint firstItem="QoS-Bg-A01" firstAttribute="firstBaseline" secondItem="QoS-Df-A01" secondAttribute="firstBaseline" id="QoS-Bg-K02"/>
+                <constraint firstItem="QoS-Hp-A01" firstAttribute="leading" secondItem="kCf-gA-qTB" secondAttribute="leading" id="QoS-Hp-K01"/>
+                <constraint firstAttribute="trailing" secondItem="QoS-Hp-A01" secondAttribute="trailing" constant="20" symbolic="YES" id="QoS-Hp-K02"/>
+                <constraint firstItem="QoS-Hp-A01" firstAttribute="top" secondItem="QoS-Df-A01" secondAttribute="bottom" constant="6" id="QoS-Hp-K03"/>
                 <constraint firstAttribute="trailing" secondItem="N0T-mL-rWn" secondAttribute="trailing" constant="20" symbolic="YES" id="uZa-6N-IxU"/>
                 <constraint firstItem="N0T-mL-rWn" firstAttribute="top" secondItem="X8z-m3-H7F" secondAttribute="bottom" constant="8" symbolic="YES" id="upT-DS-vcQ"/>
                 <constraint firstItem="bgQ-af-R3Y" firstAttribute="firstBaseline" secondItem="kCf-gA-qTB" secondAttribute="firstBaseline" id="r3e-1n-EcE"/>
                 <constraint firstItem="tYl-sb-Hga" firstAttribute="leading" secondItem="kCf-gA-qTB" secondAttribute="leading" id="tVU-d6-WRW"/>
-                <constraint firstItem="tYl-sb-Hga" firstAttribute="top" secondItem="N0T-mL-rWn" secondAttribute="bottom" constant="12" id="uMJ-HV-WQG"/>
+                <constraint firstItem="tYl-sb-Hga" firstAttribute="top" secondItem="QoS-Hp-A01" secondAttribute="bottom" constant="12" id="uMJ-HV-WQG"/>
                 <constraint firstItem="9Rm-9W-VFZ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="NQY-Se-yQr" secondAttribute="trailing" constant="7" id="ucj-yE-cmL"/>
                 <constraint firstItem="SPp-6x-JiZ" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="20" symbolic="YES" id="udY-T2-UbN"/>
                 <constraint firstItem="kCf-gA-qTB" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="20" symbolic="YES" id="xAJ-NF-i59"/>

--- a/syncthing/DaemonProcess.swift
+++ b/syncthing/DaemonProcess.swift
@@ -72,6 +72,19 @@ let MaxKeepLogLines = 200
         return environment
     }
 
+    private func launchQualityOfService() -> QualityOfService {
+        let value = UserDefaults.standard.string(forKey: "DaemonQualityOfService") ?? "background"
+
+        switch value {
+        case "default":
+            return .default
+        case "utility":
+            return .utility
+        default:
+            return .background
+        }
+    }
+
     @objc func launch() {
         queue.async {
             self.launchSync()
@@ -105,7 +118,7 @@ let MaxKeepLogLines = 200
         p.standardOutput = pipeIntoLineBuffer()
         p.standardError = pipeIntoLineBuffer()
         p.terminationHandler = { p in self.queue.async { self.didTerminate(p) } }
-        p.qualityOfService = QualityOfService.background
+        p.qualityOfService = launchQualityOfService()
         p.launch()
 
         DispatchQueue.main.async {

--- a/syncthing/STPreferencesWindowGeneralViewController.h
+++ b/syncthing/STPreferencesWindowGeneralViewController.h
@@ -16,6 +16,9 @@
 @property (weak) IBOutlet NSTextField *Syncthing_ApiKey;
 @property (weak) IBOutlet NSButton *StartAtLogin;
 @property (weak) IBOutlet NSButton *buttonTest;
+@property (weak) IBOutlet NSButton *DaemonQoSDefault;
+@property (weak) IBOutlet NSButton *DaemonQoSUtility;
+@property (weak) IBOutlet NSButton *DaemonQoSBackground;
 
 extern NSNotificationName const STDaemonNeedsRestartNotification;
 

--- a/syncthing/STPreferencesWindowGeneralViewController.m
+++ b/syncthing/STPreferencesWindowGeneralViewController.m
@@ -12,6 +12,17 @@
 
 NSNotificationName const STDaemonNeedsRestartNotification = @"STDaemonNeedsRestartNotification";
 
+static NSString * const STDaemonQualityOfServiceKey = @"DaemonQualityOfService";
+static NSString * const STDaemonQualityOfServiceDefault = @"default";
+static NSString * const STDaemonQualityOfServiceUtility = @"utility";
+static NSString * const STDaemonQualityOfServiceBackground = @"background";
+
+typedef NS_ENUM(NSInteger, STDaemonQualityOfServiceTag) {
+    STDaemonQualityOfServiceTagDefault = 0,
+    STDaemonQualityOfServiceTagUtility = 1,
+    STDaemonQualityOfServiceTagBackground = 2,
+};
+
 @interface STPreferencesWindowGeneralViewController ()
 
 @end
@@ -21,6 +32,7 @@ NSNotificationName const STDaemonNeedsRestartNotification = @"STDaemonNeedsResta
 - (void) viewDidLoad {
     [super viewDidLoad];
     [self updateProxyControls];
+    [self updateDaemonQualityOfServiceControls];
     [self updateTestButton];
 }
 
@@ -70,12 +82,52 @@ NSNotificationName const STDaemonNeedsRestartNotification = @"STDaemonNeedsResta
     [self postDaemonRestartNotification];
 }
 
+- (IBAction)clickedDaemonQualityOfService:(NSButton *)sender {
+    NSString *qualityOfService = STDaemonQualityOfServiceBackground;
+
+    switch (sender.tag) {
+        case STDaemonQualityOfServiceTagDefault:
+            qualityOfService = STDaemonQualityOfServiceDefault;
+            break;
+        case STDaemonQualityOfServiceTagUtility:
+            qualityOfService = STDaemonQualityOfServiceUtility;
+            break;
+        case STDaemonQualityOfServiceTagBackground:
+            break;
+        default:
+            return;
+    }
+
+    [[NSUserDefaults standardUserDefaults] setObject:qualityOfService forKey:STDaemonQualityOfServiceKey];
+    [self updateDaemonQualityOfServiceControls];
+    [self postDaemonRestartNotification];
+}
+
 - (void)postDaemonRestartNotification {
     [[NSNotificationCenter defaultCenter] postNotificationName:STDaemonNeedsRestartNotification object:self];
 }
 
 - (void)updateProxyControls {
     [self.ProxyURL setEnabled:(self.UseProxy.state == NSControlStateValueOn)];
+}
+
+- (void)updateDaemonQualityOfServiceControls {
+    NSString *qualityOfService = [[NSUserDefaults standardUserDefaults] stringForKey:STDaemonQualityOfServiceKey];
+    NSSet<NSString *> *validValues = [NSSet setWithObjects:
+        STDaemonQualityOfServiceDefault,
+        STDaemonQualityOfServiceUtility,
+        STDaemonQualityOfServiceBackground,
+        nil];
+    if (!qualityOfService || ![validValues containsObject:qualityOfService]) {
+        qualityOfService = STDaemonQualityOfServiceBackground;
+    }
+
+    self.DaemonQoSDefault.state = [qualityOfService isEqualToString:STDaemonQualityOfServiceDefault]
+        ? NSControlStateValueOn : NSControlStateValueOff;
+    self.DaemonQoSUtility.state = [qualityOfService isEqualToString:STDaemonQualityOfServiceUtility]
+        ? NSControlStateValueOn : NSControlStateValueOff;
+    self.DaemonQoSBackground.state = [qualityOfService isEqualToString:STDaemonQualityOfServiceBackground]
+        ? NSControlStateValueOn : NSControlStateValueOff;
 }
 
 @end

--- a/syncthing/en.lproj/STPreferencesWindowGeneralView.strings
+++ b/syncthing/en.lproj/STPreferencesWindowGeneralView.strings
@@ -25,3 +25,18 @@
 
 /* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "nB8-OA-X1F"; */
 "nB8-OA-X1F.title" = "Show in menu bar";
+
+/* Class = "NSTextFieldCell"; title = "Priority"; ObjectID = "QoS-Lb-C01"; */
+"QoS-Lb-C01.title" = "Priority";
+
+/* Class = "NSButtonCell"; title = "Normal"; ObjectID = "QoS-Df-C01"; */
+"QoS-Df-C01.title" = "Normal";
+
+/* Class = "NSButtonCell"; title = "Utility"; ObjectID = "QoS-Ut-C01"; */
+"QoS-Ut-C01.title" = "Utility";
+
+/* Class = "NSButtonCell"; title = "Background"; ObjectID = "QoS-Bg-C01"; */
+"QoS-Bg-C01.title" = "Background";
+
+/* Class = "NSTextFieldCell"; title = "Background saves energy but can make large scans slower. Changes restart Syncthing automatically."; ObjectID = "QoS-Hp-C01"; */
+"QoS-Hp-C01.title" = "Background saves energy but can make large scans slower. Changes restart Syncthing automatically.";

--- a/syncthing/es.lproj/STPreferencesWindowGeneralView.strings
+++ b/syncthing/es.lproj/STPreferencesWindowGeneralView.strings
@@ -25,3 +25,18 @@
 
 /* Class = "NSButtonCell"; title = "Show in menu bar"; ObjectID = "nB8-OA-X1F"; */
 "nB8-OA-X1F.title" = "Mostrar en la barra de menú";
+
+/* Class = "NSTextFieldCell"; title = "Priority"; ObjectID = "QoS-Lb-C01"; */
+"QoS-Lb-C01.title" = "Prioridad";
+
+/* Class = "NSButtonCell"; title = "Normal"; ObjectID = "QoS-Df-C01"; */
+"QoS-Df-C01.title" = "Normal";
+
+/* Class = "NSButtonCell"; title = "Utility"; ObjectID = "QoS-Ut-C01"; */
+"QoS-Ut-C01.title" = "Utilidad";
+
+/* Class = "NSButtonCell"; title = "Background"; ObjectID = "QoS-Bg-C01"; */
+"QoS-Bg-C01.title" = "Segundo plano";
+
+/* Class = "NSTextFieldCell"; title = "Background saves energy but can make large scans slower. Changes restart Syncthing automatically."; ObjectID = "QoS-Hp-C01"; */
+"QoS-Hp-C01.title" = "Segundo plano ahorra energía, pero puede ralentizar los análisis grandes. Los cambios reinician Syncthing automáticamente.";


### PR DESCRIPTION
## Summary

The macOS wrapper currently launches Syncthing with background QoS unconditionally, which can make full scans of large folders substantially slower. This adds Normal, Utility, and Background choices to Preferences, persists the selection, and applies it when launching the managed Syncthing process. Changing the setting restarts the process automatically. The new preference is documented in the README.

Closes #293

## Testing

- `make debug`
- Launched the resulting app on macOS 15.6 (Apple Silicon).
- Switched between Normal, Utility, and Background, verified that changes restart Syncthing, and verified that the health endpoint returns `OK`.
- Used Normal and Utility with a folder containing about 393,000 local files; both avoid the severe slowdown observed with Background.
- Continued using Utility in daily use since late July, with no issues observed as of September 17.

The performance improvement with Normal and Utility is based on real-world use; controlled comparative scan timings have not been recorded.

## Compatibility

If the preference has never been set, or contains an unknown value, the app continues to use Background. This preserves the behavior of existing installations. The setting is independent of Syncthing's own `setLowPriority` option.
