### PR TITLE
ci: automate releases when upstream Syncthing publishes a new version

### DIFF
--- a/.github/workflows/build-syncthing-macos.yml
+++ b/.github/workflows/build-syncthing-macos.yml
@@ -94,18 +94,97 @@ jobs:
         with:
           name: syncthing-macos-v2-dmg-release
 
-      - name: Notarize binaries
+      - name: Notarize and staple binaries
         run: |
+          set -euo pipefail
           APPSTORECONNECT_API_KEY_PATH="$RUNNER_TEMP/apikey.p8"
           echo "$APPSTORECONNECT_API_KEY" | base64 -d -o "$APPSTORECONNECT_API_KEY_PATH"
           for file in Syncthing-*.dmg ; do
-            xcrun notarytool submit \
+            echo "-- Submitting $file for notarization"
+            result="$(xcrun notarytool submit "$file" \
               -k "$APPSTORECONNECT_API_KEY_PATH" \
               -d "$APPSTORECONNECT_API_KEY_ID" \
               -i "$APPSTORECONNECT_API_KEY_ISSUER" \
-              $file
+              --wait --output-format json)"
+            echo "$result"
+            status="$(echo "$result" | python3 -c 'import sys,json; print(json.load(sys.stdin)["status"])')"
+            if [ "$status" != "Accepted" ]; then
+              echo "::error::Notarization of $file failed with status: $status"
+              exit 1
+            fi
+            echo "-- Stapling notarization ticket into $file"
+            xcrun stapler staple "$file"
           done
         env:
           APPSTORECONNECT_API_KEY: ${{ secrets.APPSTORECONNECT_API_KEY }}
           APPSTORECONNECT_API_KEY_ID: ${{ secrets.APPSTORECONNECT_API_KEY_ID }}
           APPSTORECONNECT_API_KEY_ISSUER: ${{ secrets.APPSTORECONNECT_API_KEY_ISSUER }}
+
+      - name: Upload notarized DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: syncthing-macos-v2-dmg-notarized
+          path: Syncthing-*.dmg
+
+  publish-release:
+    name: Publish GitHub Release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/v2'
+    needs:
+      - notarize
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      published: ${{ steps.publish.outputs.published }}
+    steps:
+      - name: Download notarized DMG
+        uses: actions/download-artifact@v4
+        with:
+          name: syncthing-macos-v2-dmg-notarized
+
+      - name: Create release when the bundled version is new
+        id: publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          dmg="$(ls Syncthing-*.dmg | head -1)"
+          if [ -z "$dmg" ]; then
+            echo "::error::No notarized DMG found to publish"
+            exit 1
+          fi
+          # create-dmg.sh names the file Syncthing-<CFBundleShortVersionString>.dmg,
+          # e.g. Syncthing-2.1.2-1.dmg -> app version 2.1.2-1, tag v2.1.2-1.
+          appver="$(basename "$dmg" .dmg | sed -E 's/^Syncthing-//')"
+          tag="v${appver}"
+          stver="${appver%-*}"   # upstream Syncthing version, e.g. 2.1.2
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag already exists; nothing new to publish."
+            echo "published=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          notes="Bundles Syncthing v${stver}.
+
+          Upstream release notes: https://github.com/syncthing/syncthing/releases/tag/v${stver}"
+          gh release create "$tag" \
+            --target "$GITHUB_SHA" \
+            --title "$tag" \
+            --notes "$notes" \
+            "$dmg"
+          echo "published=true" >> "$GITHUB_OUTPUT"
+
+  regenerate-appcast:
+    name: Regenerate appcast
+    if: needs.publish-release.result == 'success' && needs.publish-release.outputs.published == 'true'
+    needs:
+      - publish-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger appcast generation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        # workflow_dispatch triggered via GITHUB_TOKEN is exempt from GitHub's
+        # anti-recursion rule, so no PAT is needed here.
+        run: gh workflow run generate-appcast.yml --ref v2

--- a/.github/workflows/build-syncthing-macos.yml
+++ b/.github/workflows/build-syncthing-macos.yml
@@ -105,7 +105,7 @@ jobs:
               -k "$APPSTORECONNECT_API_KEY_PATH" \
               -d "$APPSTORECONNECT_API_KEY_ID" \
               -i "$APPSTORECONNECT_API_KEY_ISSUER" \
-              --wait --output-format json)"
+              --wait --timeout 30m --output-format json)"
             echo "$result"
             status="$(echo "$result" | python3 -c 'import sys,json; print(json.load(sys.stdin)["status"])')"
             if [ "$status" != "Accepted" ]; then

--- a/.github/workflows/update-upstream-release.yml
+++ b/.github/workflows/update-upstream-release.yml
@@ -1,0 +1,93 @@
+name: Update from upstream Syncthing release
+
+# Detects a new upstream `syncthing/syncthing` stable v2 release and opens a
+# version-bump PR against `v2`. Merging that PR triggers
+# `build-syncthing-macos.yml`, which builds, notarizes and publishes the
+# release (see the `publish-release` job there).
+#
+# This job only opens a PR; it never touches the packaging/signing path
+# directly, so a human reviews the bump before any signed binary is built.
+
+on:
+  schedule:
+    # Daily at 06:00 UTC. Scheduled workflows only run from the default branch.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    name: Bump bundled Syncthing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Update bundle to latest upstream stable v2 release
+        run: |
+          python3 -m pip install --upgrade pip semver
+          # update-release.py uses paths relative to its own directory.
+          cd cmd/update-release
+          python3 update-release.py
+
+      - name: Detect version change
+        id: detect
+        run: |
+          if git diff --quiet -- syncthing/Info.plist syncthing/Scripts/syncthing-resource.sh; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Already bundling the latest upstream stable v2 release; nothing to do."
+            exit 0
+          fi
+          version="$(grep -m1 '^SYNCTHING_VERSION=' syncthing/Scripts/syncthing-resource.sh \
+            | sed -E 's/^SYNCTHING_VERSION="?([^"]+)"?.*/\1/')"
+          if [ -z "$version" ]; then
+            echo "::error::Could not parse SYNCTHING_VERSION from syncthing-resource.sh"
+            exit 1
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Detected new upstream Syncthing version: v$version"
+
+      - name: Open version-bump PR
+        if: steps.detect.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.detect.outputs.version }}
+        run: |
+          set -euo pipefail
+          BRANCH="automation/bump-syncthing-v${VERSION}"
+          TITLE="Bump bundled Syncthing to v${VERSION}"
+          BODY="Automated bump of the bundled Syncthing binary to upstream stable release **v${VERSION}**.
+
+          Upstream release notes: https://github.com/syncthing/syncthing/releases/tag/v${VERSION}
+
+          Merging this PR to \`v2\` triggers the build, notarization and release
+          publishing pipeline (\`build-syncthing-macos.yml\`).
+
+          _Opened automatically by \`update-upstream-release.yml\`._"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Deterministic branch per version; force-update if it already exists
+          # so re-runs refresh the same PR instead of failing.
+          git switch -C "$BRANCH"
+          git add syncthing/Info.plist syncthing/Scripts/syncthing-resource.sh
+          git commit -m "$TITLE"
+          git push --force-with-lease origin "$BRANCH"
+
+          # Create the PR only if one isn't already open for this branch.
+          if [ -n "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+            echo "An open PR already exists for $BRANCH; it now points at the refreshed commit."
+          else
+            gh pr create --base v2 --head "$BRANCH" --title "$TITLE" --body "$BODY"
+          fi


### PR DESCRIPTION
AI usage note: I generated this with the help of Claude Opus at XHigh effort. I've reviewed every line myself. I am a professional software engineer with 15+ years of experience and was a senior SWE at a FANG company.

The `build-syncthing-macos` changes can be dropped if desired and are definitely more of a guess on my part because I'm not super familiar with the release process. At lease the auto-PR to bump the release version might be useful just as an automatic notification that there's a new reason to release/update syncthing-macos. If we don't want the auto push to Sparkle  just from merging the bump PR, let me know and I can adjust.

## Summary

Automates the currently-manual release process so a new `syncthing-macos` release is produced whenever upstream `syncthing/syncthing` publishes a new **stable v2** version. A maintainer merges a bump PR before any signed binary is built and shipped to the Sparkle auto-updater.

## Motivation

Releasing is manual today:

1. Run `make update-release` locally to bump `syncthing/Info.plist` + `syncthing/Scripts/syncthing-resource.sh` to the latest upstream tag.
2. Commit/push to `v2` → `build-syncthing-macos.yml` builds + signs the DMG and **submits** it for notarization (without waiting or stapling).
3. Someone manually downloads the artifact and creates the GitHub Release + attaches the DMG.
4. Someone manually dispatches `generate-appcast.yml` to refresh the Sparkle feed.

This PR closes the manual gaps and adds detection of new upstream releases.

## Flow

```
[schedule: daily]                         (maintainer)         [push to v2]
update-upstream-release.yml  ──opens──▶  bump PR  ──merge──▶  build-syncthing-macos.yml
  • make update-release                                          • build-release  (sign DMG)
  • diff? → open/update PR to v2                                 • notarize       (submit --wait + staple)
                                                                 • publish-release (NEW, guarded on new tag)
                                                                 • regenerate-appcast (NEW)
```

## Changes

### New — `.github/workflows/update-upstream-release.yml`
- Runs daily on `schedule` (06:00 UTC) and on-demand via `workflow_dispatch`.
- Reuses the existing `cmd/update-release/update-release.py` to rewrite the packaging metadata to the latest upstream **stable v2** release.
- Opens a version-bump PR against `v2` only when the version actually changes; idempotent per version (re-runs refresh the same branch/PR).
- Touches only packaging metadata — never the signing path — so a human reviews the bump first.

### Changed — `.github/workflows/build-syncthing-macos.yml`
- **`notarize`**: now `xcrun notarytool submit --wait`, fails the job unless the status is `Accepted`, then `xcrun stapler staple`s the ticket into the DMG and uploads the stapled artifact. (Previously fire-and-forget, never stapled.)
- **New `publish-release`**: creates the GitHub Release with the notarized DMG, deriving the tag from the DMG name (`Syncthing-2.1.5-1.dmg` → `v2.1.5-1`). Guarded so it only fires when the tag is new — ordinary `v2` pushes stay inert, and merging a bump PR cuts exactly one release.
- **New `regenerate-appcast`**: triggers the existing `generate-appcast.yml` via `gh workflow run`, only when a new release was actually published.

## Design decisions
- **PR-gated** — one maintainer merge before signed binaries ship to auto-update.
- **Stable releases only** — matches `update-release.py`'s `allow_prerelease=False` default.

## ⚠️ Repo settings this relies on
- **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** must be enabled, otherwise the bump job cannot open its PR (fails with `GitHub Actions is not permitted to create or approve pull requests`). Alternative: change the `gh pr create` step to use a PAT / GitHub App token.
- The existing `signing` and `appcast` environment secrets are used unchanged.

## Testing
Ran `update-upstream-release.yml` via `workflow_dispatch` in a fork: it detected upstream **v2.1.5**, bumped `Info.plist` + `syncthing-resource.sh`, pushed the branch, and attempted to open the bump PR. The only blocker was the "Allow GitHub Actions to create PRs" toggle above. The full signed → notarize → staple → publish → appcast path depends on the repo's environment secrets (which forks don't inherit) and will first run on merge here.

## Notes / limitations
- A wrapper-only change that reuses the same upstream Syncthing version won't auto-cut a release; that still needs a manual `distVersion` bump (the `-1` suffix), as today.
- PRs opened with the default `GITHUB_TOKEN` don't trigger the PR's own debug build (GitHub anti-recursion); the real build runs post-merge on `v2`. Use a PAT/App token if PR-time CI is desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
